### PR TITLE
Bbg real temp support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ An instance of Guerilla manages jobs and provides a UI to view job results. A jo
 * [Guerilla Tasks](wiki/Tasks.md)
 * [Custom Tasks](wiki/CustomTasks.md)
 * [Guerilla on VMs](wiki/VM.md)
+* [Deploying to a farm](wiki/Deploy.md)
 * [FAQs](wiki/FAQs.md)
 
 ### License

--- a/lib/config.js
+++ b/lib/config.js
@@ -12,6 +12,7 @@
 
 var fs = require('fs-extra');
 var path = require('path');
+var temp = require('temp').track();
 var url = require('url');
 var argv = require('yargs')
     .usage('Usage: $0 {--master | --worker} [--config ConfigFile]')
@@ -40,7 +41,6 @@ function processPath(aPath, aMessage) {
 }
 
 function getConfigPath(mode) {
-    logger.i("argv.test="+ argv.test);
     if (argv.config) {
         return processPath(argv.config, '--config command line flag detected. Config is from: ');
     }
@@ -120,6 +120,7 @@ function Config() {
             this.data_dir = '~/Guerilla';
         }
         this.data_dir = expandTilde(this.data_dir);
+        this.temp_dir = temp.mkdirsSync("guerillatemp")
     }
 
 }
@@ -137,7 +138,7 @@ Config.prototype.getResultsDir = function () {
 }
 
 Config.prototype.getTempDir = function () {
-    return path.join(this.getDataDir(), 'Temp');
+    return this.temp_dir;
 }
 
 Config.prototype.getUrl = function () {

--- a/lib/config.js
+++ b/lib/config.js
@@ -120,7 +120,7 @@ function Config() {
             this.data_dir = '~/Guerilla';
         }
         this.data_dir = expandTilde(this.data_dir);
-        this.temp_dir = temp.mkdirsSync("guerillatemp")
+        this.temp_dir = temp.mkdirSync("guerillatemp");
     }
 
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -40,6 +40,7 @@ function processPath(aPath, aMessage) {
 }
 
 function getConfigPath(mode) {
+    logger.i("argv.test="+ argv.test);
     if (argv.config) {
         return processPath(argv.config, '--config command line flag detected. Config is from: ');
     }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
         "redis-lock": "^0.1.0",
         "request": "^2.51.0",
         "serve-favicon": "^2.3.0",
+        "temp": "^0.8.3",
         "underscore": "^1.8.3",
         "yargs": "^3.15.0"
     }

--- a/wiki/Deploy.md
+++ b/wiki/Deploy.md
@@ -1,0 +1,89 @@
+## Deploy
+
+"Deploy" refers to deploying Guerilla on a farm of servers.
+
+We support using PM2 to deploy and manage the distributed farm of servers.
+
+###Philosophy
+
+We prefer to deploy with VirtualMachines to ease the setup.
+
+We Want our VMs to be largely stateless-we want to be able to replace them and not lose stored data. We have the stateful 
+Guerilla files stored in the Host's file system by utilizing the config files "data_dir" parameter. A sample vmware vmrun
+command is 
+
+```vmrun addSharedFolder ~/Documents/Virtual\ Machines.localized/OS\ X\ 10.10.vmwarevm/OS\ X\ 10.10.vmx hostDataDir ~/Documents/sharing/guerilla/reasonfeed-vm/DataDir```
+
+```vmrun setSharedFolderState ~/Documents/Virtual\ Machines.localized/OS\ X\ 10.10.vmwarevm/OS\ X\ 10.10.vmx hostDataDir ~/Documents/sharing/guerilla/reasonfeed-vm/DataDir writable```
+
+where "reasonfeed-lm" is a unique identifier for the VM. This way >1 vm can share the host's file system. The vm will use
+the path ```~/Desktop/VMware\ Shared\ Folders/hostDataDir/```
+
+
+### Using PM2
+
+### Key files
+
+* ecosystem-master.json
+* ecosystem-worker.json
+
+These describe our two applications. We divide them in different ecosystem files so that we can distribute and manage 
+master to a single server. There may be a better way to do this.
+
+
+Setup
+It is beyond our scope to setup PM2. Refer to the PM2 website directions. Note that they recommend committing the set
+of node modules to git to ensure that all of the servers are identical. A possible alternative is to use npm's shrinkwrap
+feature.
+
+Key notes:
+
+* We setup .bashrc because PM2's remote usage is not interactive and therefore doesn't use .bash_profile
+* PM2 requires a no-passphrase git ssh key.
+* We setup path and Env Vars in .bashrc to point to our config files. They must be in .bashrc as pm2 uses a non-interactive shell
+so .bash_profile is not used.
+* We setup our configs  as a directory tree..,
+
+Question: can our vms go to a single place for their output dir, and we map that to distinct subfolders on their host?
+
+
+### Key PM2 commands
+
+#### Setup
+
+```pm2 deploy ecosystem-master.json dev setup```
+
+```pm2 deploy ecosystem-worker.json dev setup```
+
+
+#### Deploy the system 
+
+```pm2 deploy ecosystem-master.json dev```
+
+```pm2 deploy ecosystem-worker.json dev```
+
+
+#### Start
+
+```pm2 deploy ecosystem-master.json dev exec "pm2 start all"```
+
+```pm2 deploy ecosystem-worker.json dev exec "pm2 start all"```
+
+#### Update
+updates then restarts or starts the application. Also starts pm2 if it isn't started.
+
+```pm2 deploy ecosystem-master.json dev update```
+
+```pm2 deploy ecosystem-worker.json dev update```
+
+#### Display status
+
+```pm2 deploy ecosystem-master.json dev exec "pm2 list"```
+
+```pm2 deploy ecosystem-master.json dev exec "pm2 list"```
+
+#### Stop a server
+
+```pm2 deploy ecosystem-master.json dev exec "pm2 delete guerilla-master"```
+
+```pm2 deploy ecosystem-worker.json dev exec "pm2 delete guerilla-worker"```


### PR DESCRIPTION
Uses real temp files. This was forced by a vmware fusion/git bug, but it's a good thing since we really want to use local temporary files for this. When the data_dir is set to a host share, a git error ensues per https://communities.vmware.com/thread/478329  (we get the error fatal: could not create work tree dir 'xxxxxxx'.: Input/output error.) Note I can create the dir tree with mkdir -p, -there appears to be nothing wrong with the permissions.

Also started updating the deploy docs. More to come.
